### PR TITLE
Add colored directories, curl installer, and Nix flake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Run
 curl -fsSL https://raw.githubusercontent.com/shrivastava95/treesmart/main/install.sh | bash
 ```
 
+OR
+
+Install with Nix (flake-enabled)
+
+```bash
+# Run without installing
+nix run github:shrivastava95/treesmart
+
+# Install into your profile
+nix profile install github:shrivastava95/treesmart
+```
+
 # Usage
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -5,12 +5,24 @@
 * limits the **number of entries per directory** (default 10)
 * limits **recursion depth** (default 3)
 
+## Installation
+
 ```bash
 # install via git remote
 pip install git+https://github.com/shrivastava95/treesmart.git
 
 # install from source
 pip install .
+```
+
+OR
+
+Make sure that `~/.local/bin` is in your `PATH`. 
+
+Run
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/shrivastava95/treesmart/main/install.sh | bash
 ```
 
 # Usage

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1754635909,
+        "narHash": "sha256-LPAZ2WxXHOK24Jmf6zKD4Yf7leK4yDdWZoTHu/ZgVuQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dfe6a41c3691b4a3b93e3a5afe296c88cabf7cb8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "treesmart - tree with depth & entry limits";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system:
+        f (import nixpkgs { inherit system; }));
+    in {
+      packages = forAllSystems (pkgs: {
+        default = pkgs.stdenv.mkDerivation {
+          pname = "treesmart";
+          version = "git"; 
+
+          src = ./.;
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp treesmart/treesmart.sh $out/bin/treesmart
+            chmod +x $out/bin/treesmart
+          '';
+        };
+      });
+
+      apps = forAllSystems (pkgs: {
+        default = {
+          type = "app";
+          program = "${self.packages.${pkgs.system}.default}/bin/treesmart";
+        };
+      });
+    };
+}
+

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+readonly DEST="$HOME/.local/bin"
+
+if command -v tput > /dev/null; then
+    readonly GREEN=$(tput setaf 2)
+    readonly RESET=$(tput sgr0)
+fi
+
+echo "Installing treesmart..."
+
+mkdir -p "$DEST"
+cp treesmart/treesmart.sh "$DEST/treesmart"
+chmod 755 "$DEST/treesmart"
+
+echo "${GREEN}Installation finished${RESET}"
+echo "Make sure $DEST is in your PATH"
+

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,8 @@ fi
 echo "Installing treesmart..."
 
 mkdir -p "$DEST"
-cp treesmart/treesmart.sh "$DEST/treesmart"
+curl -fsSL https://raw.githubusercontent.com/shrivastava95/treesmart/main/treesmart/treesmart.sh \
+    -o "$DEST/treesmart"
 chmod 755 "$DEST/treesmart"
 
 echo "${GREEN}Installation finished${RESET}"

--- a/treesmart/treesmart.sh
+++ b/treesmart/treesmart.sh
@@ -46,8 +46,8 @@ EOF
       filecnt[parent] += (type=="f")
       indent = ""; for(i=2;i<=n;i++) indent=indent"│   ";
 
-      if (type=="d") {
-          print indent "├── " basename(path);
+      if (type=="d") {          
+          print indent "├── " "\033[1;34m" basename(path) "\033[0m";
       } else if (type=="f") {
           if (filecnt[parent] <= LIMIT) {
               print indent "├── " basename(path);


### PR DESCRIPTION
This PR introduces:

1. Colored directory output – directories are now printed in bold (matching tree style) for better readability.

2. Curl-based installation – added install.sh for quick setup without cloning.

3. Nix flake support – added flake.nix and flake.lock for easy installation via nix run or nix profile install.

I am happy to maintain the Nix flake going forward.